### PR TITLE
Show every message under its own heading

### DIFF
--- a/stream.ts
+++ b/stream.ts
@@ -2,146 +2,146 @@ import { Editor, Notice } from "obsidian";
 import { SSE } from "sse";
 
 export interface OpenAIStreamPayload {
-	model: string;
-	messages: Array<{ role: string; content: string }>;
-	temperature: number;
-	top_p: number;
-	presence_penalty: number;
-	frequency_penalty: number;
-	stop: string[] | null;
-	n: number;
-	logit_bias?: any | null;
-	user?: string | null;
-	max_tokens: number;
-	stream: boolean;
+  model: string;
+  messages: Array<{ role: string; content: string }>;
+  temperature: number;
+  top_p: number;
+  presence_penalty: number;
+  frequency_penalty: number;
+  stop: string[] | null;
+  n: number;
+  logit_bias?: any | null;
+  user?: string | null;
+  max_tokens: number;
+  stream: boolean;
 }
 
 // todo: await this function and return the text on stream completion
 export const streamSSE = async (
-	editor: Editor,
-	apiKey: string,
-	options: OpenAIStreamPayload,
-	setAtCursor: boolean,
-	headingPrefix: string
+  editor: Editor,
+  apiKey: string,
+  options: OpenAIStreamPayload,
+  setAtCursor: boolean,
+  headingPrefix: string
 ) => {
-	return new Promise((resolve, reject) => {
-		try {
-			console.log("streamSSE", options);
+  return new Promise((resolve, reject) => {
+    try {
+      console.log("streamSSE", options);
 
-			const url = "https://api.openai.com/v1/chat/completions";
+      const url = "https://api.openai.com/v1/chat/completions";
 
-			const source = new SSE(url, {
-				headers: {
-					"Content-Type": "application/json",
-					Authorization: `Bearer ${apiKey}`,
-				},
-				method: "POST",
-				payload: JSON.stringify(options),
-			});
+      const source = new SSE(url, {
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        method: "POST",
+        payload: JSON.stringify(options),
+      });
 
-			let txt = "";
-			let initialCursorPosCh = editor.getCursor().ch;
-			let initialCursorPosLine = editor.getCursor().line;
+      let txt = "";
+      let initialCursorPosCh = editor.getCursor().ch;
+      let initialCursorPosLine = editor.getCursor().line;
 
-			source.addEventListener("open", (e: any) => {
-				console.log("[ChatGPT MD] SSE Opened");
+      source.addEventListener("open", (e: any) => {
+        console.log("[ChatGPT MD] SSE Opened");
 
-				const newLine = `\n\n<hr class="__chatgpt_plugin">\n\n${headingPrefix}role::assistant\n\n`;
-				editor.replaceRange(newLine, editor.getCursor());
+        const newLine = `\n\n<hr class="__chatgpt_plugin">\n\n${headingPrefix}role::assistant\n\n`;
+        editor.replaceRange(newLine, editor.getCursor());
 
-				// move cursor to end of line
-				const cursor = editor.getCursor();
-				const newCursor = {
-					line: cursor.line,
-					ch: cursor.ch + newLine.length,
-				};
-				editor.setCursor(newCursor);
+        // move cursor to end of line
+        const cursor = editor.getCursor();
+        const newCursor = {
+          line: cursor.line,
+          ch: cursor.ch + newLine.length,
+        };
+        editor.setCursor(newCursor);
 
-				initialCursorPosCh = newCursor.ch;
-				initialCursorPosLine = newCursor.line;
-			});
+        initialCursorPosCh = newCursor.ch;
+        initialCursorPosLine = newCursor.line;
+      });
 
-			source.addEventListener("message", (e: any) => {
-				if (e.data != "[DONE]") {
-					const payload = JSON.parse(e.data);
-					const text = payload.choices[0].delta.content;
+      source.addEventListener("message", (e: any) => {
+        if (e.data != "[DONE]") {
+          const payload = JSON.parse(e.data);
+          const text = payload.choices[0].delta.content;
 
-					// if text undefined, then do nothing
-					if (!text) {
-						return;
-					}
+          // if text undefined, then do nothing
+          if (!text) {
+            return;
+          }
 
-					const cursor = editor.getCursor();
-					const convPos = editor.posToOffset(cursor);
+          const cursor = editor.getCursor();
+          const convPos = editor.posToOffset(cursor);
 
-					// @ts-ignore
-					const cm6 = editor.cm;
-					const transaction = cm6.state.update({
-						changes: { from: convPos, to: convPos, insert: text },
-					});
-					cm6.dispatch(transaction);
+          // @ts-ignore
+          const cm6 = editor.cm;
+          const transaction = cm6.state.update({
+            changes: { from: convPos, to: convPos, insert: text },
+          });
+          cm6.dispatch(transaction);
 
-					txt += text;
+          txt += text;
 
-					const newCursor = {
-						line: cursor.line,
-						ch: cursor.ch + text.length,
-					};
-					editor.setCursor(newCursor);
-				} else {
-					source.close();
-					console.log("[ChatGPT MD] SSE Closed");
+          const newCursor = {
+            line: cursor.line,
+            ch: cursor.ch + text.length,
+          };
+          editor.setCursor(newCursor);
+        } else {
+          source.close();
+          console.log("[ChatGPT MD] SSE Closed");
 
-					// replace the text from initialCursor to fix any formatting issues from streaming
-					const cursor = editor.getCursor();
-					editor.replaceRange(
-						txt,
-						{ line: initialCursorPosLine, ch: initialCursorPosCh },
-						cursor
-					);
+          // replace the text from initialCursor to fix any formatting issues from streaming
+          const cursor = editor.getCursor();
+          editor.replaceRange(
+            txt,
+            { line: initialCursorPosLine, ch: initialCursorPosCh },
+            cursor
+          );
 
-					// set cursor to end of replacement text
-					const newCursor = {
-						line: initialCursorPosLine,
-						ch: initialCursorPosCh + txt.length,
-					};
-					editor.setCursor(newCursor);
+          // set cursor to end of replacement text
+          const newCursor = {
+            line: initialCursorPosLine,
+            ch: initialCursorPosCh + txt.length,
+          };
+          editor.setCursor(newCursor);
 
-					if (!setAtCursor) {
-						// remove the text after the cursor
-						editor.replaceRange("", newCursor, {
-							line: Infinity,
-							ch: Infinity,
-						});
-					} else {
-						new Notice(
-							"[ChatGPT MD] Text pasted at cursor may leave artifacts. Please remove them manually. ChatGPT MD cannot safely remove text when pasting at cursor."
-						);
-					}
+          if (!setAtCursor) {
+            // remove the text after the cursor
+            editor.replaceRange("", newCursor, {
+              line: Infinity,
+              ch: Infinity,
+            });
+          } else {
+            new Notice(
+              "[ChatGPT MD] Text pasted at cursor may leave artifacts. Please remove them manually. ChatGPT MD cannot safely remove text when pasting at cursor."
+            );
+          }
 
-					resolve(txt);
-					// return txt;
-				}
-			});
+          resolve(txt);
+          // return txt;
+        }
+      });
 
-			source.addEventListener("error", (e: any) => {
-				try {
-					console.log("[ChatGPT MD] SSE Error: ", JSON.parse(e.data));
-					source.close();
-					console.log("[ChatGPT MD] SSE Closed");
-					reject(JSON.parse(e.data));
-				} catch (err) {
-					console.log("[ChatGPT MD] Unknown Error: ", e);
-					source.close();
-					console.log("[ChatGPT MD] SSE Closed");
-					reject(e);
-				}
-			});
+      source.addEventListener("error", (e: any) => {
+        try {
+          console.log("[ChatGPT MD] SSE Error: ", JSON.parse(e.data));
+          source.close();
+          console.log("[ChatGPT MD] SSE Closed");
+          reject(JSON.parse(e.data));
+        } catch (err) {
+          console.log("[ChatGPT MD] Unknown Error: ", e);
+          source.close();
+          console.log("[ChatGPT MD] SSE Closed");
+          reject(e);
+        }
+      });
 
-			source.stream();
-		} catch (err) {
-			console.log("SSE Error", err);
-			reject(err);
-		}
-	});
+      source.stream();
+    } catch (err) {
+      console.log("SSE Error", err);
+      reject(err);
+    }
+  });
 };


### PR DESCRIPTION
Make it possible to configure `role::user|assistant` to be headings e.g. `## role::user`

Setting the setting to 0 deactivates the functionality.

I set heading level 2 as default here, but you can change it to 0 if you don't like it as default.