### PR TITLE
Added linking new pages created from highlighted text

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -771,8 +771,10 @@ export default class ChatGPT_MD extends Plugin {
 							new Date(),
 							this.settings.dateFormat
 						)}.md`,
-						`${this.settings.defaultChatFrontmatter}\n\n${selectedText}`
+						`${this.settings.defaultChatFrontmatter}\n\n[${selectedText}](${encodeURIComponent(view.file.name)})`
 					);
+
+				  	editor.replaceSelection(`[${selectedText}](${encodeURIComponent(newFile.name)})`);
 
 					// open new file
 					await this.app.workspace.openLinkText(


### PR DESCRIPTION
Creates the ability to add a link to a newly created page from a highlighted segment. This feature supports the graph view while exploring a new topic with GPT.