### PR TITLE
Validates if model or url exist in the default settings

### DIFF
--- a/src/Services/AiService.ts
+++ b/src/Services/AiService.ts
@@ -249,5 +249,5 @@ export const aiProviderFromUrl = (url?: string, model?: string): string => {
   if (url?.includes("localhost") || url?.includes("127.0.0.1")) {
     return AI_SERVICE_OLLAMA;
   }
-  return AI_SERVICE_OPENAI;
+  return "";
 };

--- a/src/Services/FrontmatterService.ts
+++ b/src/Services/FrontmatterService.ts
@@ -20,7 +20,7 @@ export class FrontmatterService {
     const frontmatter = parseSettingsFrontmatter(view.editor.getValue());
 
     // Determine the AI service type
-    const aiService =
+    let aiService =
       frontmatter.aiService || aiProviderFromUrl(frontmatter.url, frontmatter.model) || AI_SERVICE_OPENAI;
 
     // Get the default config for the service type
@@ -40,9 +40,10 @@ export class FrontmatterService {
     }
 
     // Parse default frontmatter from settings if it exists
-    let defaultFrontmatterSettings = {};
+    let defaultFrontmatterSettings = null;
     if (settings.defaultChatFrontmatter) {
       defaultFrontmatterSettings = parseSettingsFrontmatter(settings.defaultChatFrontmatter);
+      aiService = aiProviderFromUrl(defaultFrontmatterSettings.url, defaultFrontmatterSettings.model) || aiService;
     }
 
     // Merge the default config with the settings, default frontmatter, and file frontmatter


### PR DESCRIPTION
Validates if model or url exist in the default settings when the model is not explicitly set in the frontmatter.

Now it correctly checks if the model is not explicitly set, and in that case, it takes the one from the settings. There was a bug that caused it to default to OpenAI.