### PR TITLE
Update Config.ts

### DIFF
--- a/src/Models/Config.ts
+++ b/src/Models/Config.ts
@@ -14,6 +14,8 @@ import { DEFAULT_OLLAMA_CONFIG } from "src/Services/OllamaService";
 export interface ApiKeySettings {
   /** API Key for OpenAI */
   apiKey: string;
+  /** (Optional) ID of an OpenAI Assistant you’ve built */
+  assistantId: string;
   /** API Key for OpenRouter */
   openrouterApiKey: string;
 }
@@ -91,6 +93,7 @@ export interface ChatGPT_MDSettings
 export const DEFAULT_SETTINGS: ChatGPT_MDSettings = {
   // API Keys
   apiKey: "",
+  assistantId: "",
   openrouterApiKey: "",
 
   // Service URLs


### PR DESCRIPTION
1. Add an assistantId to your settings

In src/Models/Config.ts, extend the ApiKeySettings and DEFAULT_SETTINGS:

 export interface ApiKeySettings {
   /** API Key for OpenAI */
   apiKey: string;
+  /** (Optional) ID of an OpenAI Assistant you’ve built */
+  assistantId: string; /** API Key for OpenRouter */ openrouterApiKey: string; } …
 export const DEFAULT_SETTINGS: ChatGPT_MDSettings = {
   // API Keys apiKey: "",
+  assistantId: "", openrouterApiKey: "", … };