### PR TITLE
fix: keep chat output in the originating note when switching notes mid-stream

### DIFF
--- a/src/Commands/ChatHandler.ts
+++ b/src/Commands/ChatHandler.ts
@@ -45,6 +45,11 @@ export class ChatHandler {
     const settings = settingsService.getSettings();
     const frontmatter: MergedFrontmatterConfig = await editorService.getFrontmatter(view, settings, this.services.app);
 
+    // Capture the originating file now. Obsidian reuses one editor per leaf and
+    // swaps its document when the user navigates to another note, so we must
+    // pin all output to this file rather than to the live editor/view.
+    const targetFile = view?.file ?? null;
+
     const aiService = this.services.aiProviderService();
     this.stopStreamingHandler.setCurrentAiService(aiService);
 
@@ -87,14 +92,16 @@ export class ChatHandler {
         settings.generateAtCursor,
         apiKeyToUse,
         settings,
-        toolServiceToUse
+        toolServiceToUse,
+        this.services.app,
+        targetFile
       );
 
-      editorService.processResponse(editor, response, settings);
+      editorService.processResponse(editor, response, settings, targetFile);
 
       if (
         settings.autoInferTitle &&
-        isTitleTimestampFormat(view?.file?.basename, settings.dateFormat) &&
+        isTitleTimestampFormat(targetFile?.basename, settings.dateFormat) &&
         messagesWithRoleAndMessage.length > MIN_AUTO_INFER_MESSAGES
       ) {
         // Create a settings object with the correct API key and model
@@ -119,7 +126,7 @@ export class ChatHandler {
           }
         }
 
-        await aiService.inferTitle(view, settingsWithApiKey as ChatGPT_MDSettings, messages, editorService);
+        await aiService.inferTitle(view, settingsWithApiKey as ChatGPT_MDSettings, messages, editorService, targetFile);
       }
     } catch (err) {
       if (Platform.isMobile) {

--- a/src/Services/AiProviderService.ts
+++ b/src/Services/AiProviderService.ts
@@ -1,4 +1,4 @@
-import { Editor, MarkdownView } from "obsidian";
+import { App, Editor, MarkdownView, TFile } from "obsidian";
 import { Message } from "src/Models/Message";
 import { ChatGPT_MDSettings } from "src/Models/Config";
 import { EditorService } from "./EditorService";
@@ -181,7 +181,9 @@ export class AiProviderService implements IAiApiService {
     setAtCursor?: boolean,
     apiKey?: string,
     settings?: ChatGPT_MDSettings,
-    toolService?: ToolService
+    toolService?: ToolService,
+    app?: App,
+    targetFile?: TFile | null
   ): Promise<{ fullString: string; mode: string; wasAborted?: boolean }> {
     const config = { ...this.getDefaultConfig(), ...options };
 
@@ -194,7 +196,18 @@ export class AiProviderService implements IAiApiService {
     }
 
     return config.stream && editor
-      ? this.callStreamingAPI(apiKey, messages, config, editor, headingPrefix, setAtCursor, settings, toolService)
+      ? this.callStreamingAPI(
+          apiKey,
+          messages,
+          config,
+          editor,
+          headingPrefix,
+          setAtCursor,
+          settings,
+          toolService,
+          app,
+          targetFile
+        )
       : this.callNonStreamingAPI(apiKey, messages, config, settings, toolService);
   }
 
@@ -205,10 +218,14 @@ export class AiProviderService implements IAiApiService {
     view: MarkdownView,
     settings: ChatGPT_MDSettings,
     messages: string[],
-    editorService: EditorService
+    editorService: EditorService,
+    targetFile?: TFile | null
   ): Promise<string> {
     try {
-      if (!view.file) {
+      // Prefer the file captured when the command was invoked. The live view
+      // may already point at a different note if the user navigated away.
+      const fileToRename = targetFile ?? view.file;
+      if (!fileToRename) {
         throw new Error("No active file found");
       }
 
@@ -219,7 +236,7 @@ export class AiProviderService implements IAiApiService {
 
       if (typeof titleResponse === "string") {
         if (this.isTruncationError(titleResponse)) {
-          this.handleTitleTruncationError(view, titleResponse);
+          this.handleTitleTruncationError(view, titleResponse, fileToRename);
           this.showNoTitleInferredNotification();
           return "";
         }
@@ -229,7 +246,7 @@ export class AiProviderService implements IAiApiService {
         const responseText = responseObj.fullString || "";
 
         if (this.isTruncationError(responseText)) {
-          this.handleTitleTruncationError(view, responseText);
+          this.handleTitleTruncationError(view, responseText, fileToRename);
           this.showNoTitleInferredNotification();
           return "";
         }
@@ -238,7 +255,7 @@ export class AiProviderService implements IAiApiService {
       }
 
       if (titleStr && titleStr.trim().length > 0) {
-        await editorService.writeInferredTitle(view, titleStr.trim());
+        await editorService.writeInferredTitle(fileToRename, titleStr.trim());
         return titleStr.trim();
       } else {
         this.showNoTitleInferredNotification();
@@ -268,7 +285,14 @@ export class AiProviderService implements IAiApiService {
   /**
    * Handle truncation error in title inference
    */
-  private handleTitleTruncationError(view: MarkdownView, errorMessage: string): void {
+  private handleTitleTruncationError(view: MarkdownView, errorMessage: string, targetFile?: TFile | null): void {
+    // Only write the error into the editor if it still displays the note we
+    // were working on; otherwise the user navigated away and we must not edit
+    // the now-active note.
+    if (targetFile && view.file?.path !== targetFile.path) {
+      return;
+    }
+
     const editor = view.editor;
     const lastLine = editor.lastLine();
     const lastLineLength = editor.getLine(lastLine).length;
@@ -408,7 +432,9 @@ export class AiProviderService implements IAiApiService {
     headingPrefix: string,
     setAtCursor?: boolean,
     settings?: ChatGPT_MDSettings,
-    toolService?: ToolService
+    toolService?: ToolService,
+    app?: App,
+    targetFile?: TFile | null
   ): Promise<StreamingResponse> {
     this.ensureProvider(apiKey, config);
     const modelName = this.extractModelName(config.model);
@@ -426,7 +452,9 @@ export class AiProviderService implements IAiApiService {
       setAtCursor,
       tools,
       toolService,
-      settings
+      settings,
+      app,
+      targetFile
     );
   }
 
@@ -521,14 +549,18 @@ export class AiProviderService implements IAiApiService {
     setAtCursor?: boolean,
     tools?: unknown,
     toolService?: ToolService,
-    settings?: ChatGPT_MDSettings
+    settings?: ChatGPT_MDSettings,
+    app?: App,
+    targetFile?: TFile | null
   ): Promise<StreamingResponse> {
     const { aiSdkMessages, handler, abortController } = this.setupStreamingContext(
       messages,
       editor,
       headingPrefix,
       modelName,
-      setAtCursor
+      setAtCursor,
+      app,
+      targetFile
     );
 
     try {
@@ -558,7 +590,14 @@ export class AiProviderService implements IAiApiService {
         }
       }
 
-      if (!setAtCursor) {
+      // Ensure any output redirected to the original file has been committed
+      // before the caller appends the trailing user delimiter.
+      await handler.flushPendingFileWrites();
+
+      // Only move the visible cursor if the editor still shows the note we
+      // streamed into; otherwise the user navigated away and the cursor in the
+      // now-active note must not be touched.
+      if (!setAtCursor && handler.canWriteToEditor()) {
         editor.setCursor(handler.getCursor());
       }
 
@@ -568,7 +607,7 @@ export class AiProviderService implements IAiApiService {
         wasAborted: this.apiService.wasAborted(),
       };
     } catch (err: any) {
-      return this.handleStreamError(err, handler, editor);
+      return this.handleStreamError(err, handler);
     }
   }
 
@@ -580,7 +619,9 @@ export class AiProviderService implements IAiApiService {
     editor: Editor,
     headingPrefix: string,
     modelName: string,
-    setAtCursor?: boolean
+    setAtCursor?: boolean,
+    app?: App,
+    targetFile?: TFile | null
   ) {
     const aiSdkMessages = this.prepareAiSdkMessages(messages);
     const cursorPositions = insertAssistantHeader(editor, headingPrefix, modelName);
@@ -589,7 +630,7 @@ export class AiProviderService implements IAiApiService {
     this.apiService.setAbortController(abortController);
 
     const initialCursor = setAtCursor ? cursorPositions.initialCursor : cursorPositions.newCursor;
-    const handler = new StreamingHandler(editor, initialCursor, setAtCursor);
+    const handler = new StreamingHandler(editor, initialCursor, setAtCursor, undefined, app, targetFile);
 
     return { aiSdkMessages, handler, abortController };
   }
@@ -597,11 +638,13 @@ export class AiProviderService implements IAiApiService {
   /**
    * Handle streaming error
    */
-  private handleStreamError(err: any, handler: StreamingHandler, editor: Editor): StreamingResponse {
+  private async handleStreamError(err: any, handler: StreamingHandler): Promise<StreamingResponse> {
     handler.stopBuffering();
     const errorMessage = this.formatStreamError(err);
-    const errorCursor = handler.getCursor();
-    editor.replaceRange(errorMessage, errorCursor);
+    // Route the error to wherever the stream was going (editor or, if the user
+    // navigated away mid-stream, the original file).
+    handler.writeImmediate(errorMessage);
+    await handler.flushPendingFileWrites();
     return { fullString: errorMessage, mode: "streaming" };
   }
 
@@ -691,20 +734,26 @@ export class AiProviderService implements IAiApiService {
     toolService: ToolService,
     modelName: string
   ): Promise<string> {
-    // Insert tool notice
+    // Insert tool notice (only when the editor still shows the streamed note;
+    // if the user navigated away we skip the transient placeholder).
+    const canEdit = handler.canWriteToEditor();
     const toolNotice = "_[Tool approval required...]_\n";
-    const indicatorCursor = handler.getCursor();
-    editor.replaceRange(toolNotice, indicatorCursor);
-    handler.updateCursorAfterInsert(toolNotice, indicatorCursor);
+    if (canEdit) {
+      const indicatorCursor = handler.getCursor();
+      editor.replaceRange(toolNotice, indicatorCursor);
+      handler.updateCursorAfterInsert(toolNotice, indicatorCursor);
+    }
 
     // Execute tools
     const toolResults = await toolService.handleToolCalls(toolCalls, modelName);
     const { contextMessages } = await toolService.processToolResults(toolCalls, toolResults, modelName);
 
     // Clean up notice
-    const toolCursor = handler.getCursor();
-    editor.replaceRange("", { line: toolCursor.line - 1, ch: 0 }, toolCursor);
-    handler.setCursor({ line: toolCursor.line - 1, ch: 0 });
+    if (canEdit && handler.canWriteToEditor()) {
+      const toolCursor = handler.getCursor();
+      editor.replaceRange("", { line: toolCursor.line - 1, ch: 0 }, toolCursor);
+      handler.setCursor({ line: toolCursor.line - 1, ch: 0 });
+    }
 
     // Continue with tool results
     const updatedMessages = [...aiSdkMessages, { role: "assistant" as const, content: fullText }, ...contextMessages];

--- a/src/Services/EditorService.ts
+++ b/src/Services/EditorService.ts
@@ -1,4 +1,4 @@
-import { App, Editor, MarkdownView } from "obsidian";
+import { App, Editor, MarkdownView, TFile } from "obsidian";
 import { ChatGPT_MDSettings, MergedFrontmatterConfig } from "src/Models/Config";
 import { FileService } from "./FileService";
 import { MessageService } from "./MessageService";
@@ -44,8 +44,8 @@ export class EditorService {
 
   // FileService delegations
 
-  async writeInferredTitle(view: MarkdownView, title: string): Promise<void> {
-    return this.fileService.writeInferredTitle(view, title);
+  async writeInferredTitle(file: TFile | null, title: string): Promise<void> {
+    return this.fileService.writeInferredTitle(file, title);
   }
 
   async ensureFolderExists(folderPath: string, folderType: string): Promise<boolean> {
@@ -145,8 +145,13 @@ export class EditorService {
 
   // ResponseProcessingService delegations
 
-  processResponse(editor: Editor, response: { fullString: string; mode: string }, settings: ChatGPT_MDSettings): void {
-    this.messageService.processResponse(editor, response, settings);
+  processResponse(
+    editor: Editor,
+    response: { fullString: string; mode: string },
+    settings: ChatGPT_MDSettings,
+    targetFile?: TFile | null
+  ): void {
+    this.messageService.processResponse(editor, response, settings, this.app, targetFile);
   }
 
   /**

--- a/src/Services/FileService.ts
+++ b/src/Services/FileService.ts
@@ -1,4 +1,4 @@
-import { App, MarkdownView, Notice, TFile } from "obsidian";
+import { App, Notice, TFile } from "obsidian";
 import { createFolderModal } from "src/Utilities/ModalHelpers";
 
 /**
@@ -10,8 +10,7 @@ export class FileService {
   /**
    * Write an inferred title to a file by renaming it
    */
-  async writeInferredTitle(view: MarkdownView, title: string): Promise<void> {
-    const file = view.file;
+  async writeInferredTitle(file: TFile | null, title: string): Promise<void> {
     if (!file) {
       throw new Error("No file is currently open");
     }

--- a/src/Services/MessageService.ts
+++ b/src/Services/MessageService.ts
@@ -1,4 +1,4 @@
-import { Editor } from "obsidian";
+import { App, Editor, TFile } from "obsidian";
 import { Message } from "src/Models/Message";
 import { ChatGPT_MDSettings } from "src/Models/Config";
 import { FileService } from "./FileService";
@@ -16,6 +16,7 @@ import {
   removeYAMLFrontMatter,
   splitMessages,
 } from "../Utilities/MessageHelpers";
+import { getFileForEditor } from "../Utilities/EditorHelpers";
 
 /**
  * Service responsible for all message-related operations
@@ -166,11 +167,17 @@ export class MessageService {
   /**
    * Process an AI response and update the editor
    */
-  processResponse(editor: Editor, response: any, settings: ChatGPT_MDSettings): void {
+  processResponse(
+    editor: Editor,
+    response: any,
+    settings: ChatGPT_MDSettings,
+    app?: App,
+    targetFile?: TFile | null
+  ): void {
     if (response.mode === "streaming") {
       // Only add user section if streaming was not aborted
       if (!response.wasAborted) {
-        this.processStreamingResponse(editor, settings);
+        this.processStreamingResponse(editor, settings, app, targetFile);
       }
     } else {
       this.processStandardResponse(editor, response, settings);
@@ -180,9 +187,22 @@ export class MessageService {
   /**
    * Process a streaming response by adding user delimiter
    */
-  private processStreamingResponse(editor: Editor, settings: ChatGPT_MDSettings): void {
+  private processStreamingResponse(
+    editor: Editor,
+    settings: ChatGPT_MDSettings,
+    app?: App,
+    targetFile?: TFile | null
+  ): void {
     const headingPrefix = getHeadingPrefix(settings.headingLevel);
     const userHeader = getHeaderRole(headingPrefix, ROLE_USER);
+
+    // If the user navigated to a different note while streaming, the live
+    // editor now shows the wrong file. Append the delimiter to the original
+    // file directly instead of corrupting the now-active note.
+    if (app && targetFile && getFileForEditor(app, editor)?.path !== targetFile.path) {
+      void app.vault.process(targetFile, (data) => data + userHeader);
+      return;
+    }
 
     // Get cursor position set by ApiResponseParser after streaming completes
     const cursorBeforeHeader = editor.getCursor();

--- a/src/Services/StreamingHandler.test.ts
+++ b/src/Services/StreamingHandler.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import { MarkdownView } from "obsidian";
 import { StreamingHandler } from "./StreamingHandler";
 
 /** Minimal Editor mock that satisfies StreamingHandler + flushBufferedText */
@@ -14,6 +15,26 @@ function createMockEditor(): any {
       ch: offset % 100,
     })),
   };
+}
+
+/**
+ * Build an App mock whose single markdown leaf currently displays `editor`
+ * for the file at `displayedPath`. Lets tests simulate the editor staying on
+ * the original note or navigating away to a different one.
+ */
+function createMockApp(editor: any, displayedPath: string) {
+  const view = new (MarkdownView as any)();
+  view.editor = editor;
+  view.file = { path: displayedPath };
+
+  return {
+    workspace: {
+      getLeavesOfType: jest.fn(() => [{ view }]),
+    },
+    vault: {
+      process: jest.fn((_file: any, fn: (data: string) => string) => Promise.resolve(fn("existing "))),
+    },
+  } as any;
 }
 
 describe("StreamingHandler", () => {
@@ -124,6 +145,75 @@ describe("StreamingHandler", () => {
       handler.stopBuffering();
 
       expect(editor.replaceRange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("note-switch redirection", () => {
+    const targetFile = { path: "note-a.md" } as any;
+
+    it("writes to the editor while it still shows the original note", () => {
+      const app = createMockApp(editor, "note-a.md");
+      const guarded = new StreamingHandler(editor, { line: 0, ch: 0 }, false, undefined, app, targetFile);
+
+      guarded.appendText("hello world\n");
+      guarded.flush();
+
+      expect(editor.replaceRange).toHaveBeenCalledWith("hello world\n", { line: 0, ch: 0 });
+      expect(app.vault.process).not.toHaveBeenCalled();
+      expect(guarded.isRedirected()).toBe(false);
+      expect(guarded.canWriteToEditor()).toBe(true);
+    });
+
+    it("redirects writes to the original file when the editor navigated away", async () => {
+      // The editor now displays a different note than the one we streamed into.
+      const app = createMockApp(editor, "note-b.md");
+      const guarded = new StreamingHandler(editor, { line: 0, ch: 0 }, false, undefined, app, targetFile);
+
+      guarded.appendText("hello world\n");
+      guarded.flush();
+      await guarded.flushPendingFileWrites();
+
+      expect(editor.replaceRange).not.toHaveBeenCalled();
+      expect(app.vault.process).toHaveBeenCalledWith(targetFile, expect.any(Function));
+      expect(guarded.isRedirected()).toBe(true);
+      expect(guarded.canWriteToEditor()).toBe(false);
+    });
+
+    it("stays redirected once the editor has navigated away (sticky)", async () => {
+      const view = new (MarkdownView as any)();
+      view.editor = editor;
+      let displayedPath = "note-a.md";
+      view.file = {
+        get path() {
+          return displayedPath;
+        },
+      };
+      const app = {
+        workspace: { getLeavesOfType: jest.fn(() => [{ view }]) },
+        vault: { process: jest.fn((_f: any, fn: (d: string) => string) => Promise.resolve(fn(""))) },
+      } as any;
+
+      const guarded = new StreamingHandler(editor, { line: 0, ch: 0 }, false, undefined, app, targetFile);
+
+      // First flush while still on the original note -> editor write.
+      guarded.appendText("line 1\n");
+      guarded.flush();
+      expect(editor.replaceRange).toHaveBeenCalledTimes(1);
+
+      // User navigates away; subsequent flush redirects to the file.
+      displayedPath = "note-b.md";
+      guarded.appendText("line 2\n");
+      guarded.flush();
+      await guarded.flushPendingFileWrites();
+      expect(app.vault.process).toHaveBeenCalledTimes(1);
+
+      // Even if the user navigates back, output stays pinned to the file.
+      displayedPath = "note-a.md";
+      guarded.appendText("line 3\n");
+      guarded.flush();
+      await guarded.flushPendingFileWrites();
+      expect(editor.replaceRange).toHaveBeenCalledTimes(1);
+      expect(app.vault.process).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/Services/StreamingHandler.ts
+++ b/src/Services/StreamingHandler.ts
@@ -1,14 +1,22 @@
-import { Editor, EditorPosition } from "obsidian";
+import { App, Editor, EditorPosition, TFile } from "obsidian";
 import {
   calculateCursorAfterInsert,
   DEFAULT_FLUSH_INTERVAL_MS,
   flushBufferedText,
 } from "src/Utilities/StreamingHelpers";
+import { getFileForEditor } from "src/Utilities/EditorHelpers";
 
 /**
  * StreamingHandler manages text streaming with buffering and cursor positioning
  * Handles both direct cursor positioning and insertion at current selection
  * Now uses utility functions for common operations
+ *
+ * Note-switch safety: Obsidian reuses one Editor instance per leaf and swaps
+ * the document when the user navigates to another note in the same tab. If
+ * `app` and `targetFile` are supplied, the handler verifies the editor still
+ * displays the originating file before each write. Once the editor has
+ * navigated away, all remaining output is redirected to the original file via
+ * the vault API so streamed text never lands in the wrong note.
  */
 export class StreamingHandler {
   private static readonly MAX_BUFFER_SIZE = 10000;
@@ -20,16 +28,25 @@ export class StreamingHandler {
   private flushInterval: number;
   private setAtCursor: boolean;
 
+  private app?: App;
+  private targetFile?: TFile | null;
+  private redirected = false;
+  private fileWriteQueue: Promise<void> = Promise.resolve();
+
   constructor(
     editor: Editor,
     initialCursor: EditorPosition,
     setAtCursor: boolean = false,
-    flushInterval: number = DEFAULT_FLUSH_INTERVAL_MS
+    flushInterval: number = DEFAULT_FLUSH_INTERVAL_MS,
+    app?: App,
+    targetFile?: TFile | null
   ) {
     this.editor = editor;
     this.currentCursor = initialCursor;
     this.setAtCursor = setAtCursor;
     this.flushInterval = flushInterval;
+    this.app = app;
+    this.targetFile = targetFile;
   }
 
   /**
@@ -70,7 +87,7 @@ export class StreamingHandler {
     const toFlush = this.bufferedText.substring(0, lastNewline + 1);
     this.bufferedText = this.bufferedText.substring(lastNewline + 1);
 
-    this.currentCursor = flushBufferedText(this.editor, toFlush, this.currentCursor, this.setAtCursor);
+    this.writeChunk(toFlush);
   }
 
   /**
@@ -91,8 +108,91 @@ export class StreamingHandler {
   private forceFlush(): void {
     if (this.bufferedText.length === 0) return;
 
-    this.currentCursor = flushBufferedText(this.editor, this.bufferedText, this.currentCursor, this.setAtCursor);
+    this.writeChunk(this.bufferedText);
     this.bufferedText = "";
+  }
+
+  /**
+   * Write a chunk of text to its destination.
+   *
+   * Writes to the live editor while it still displays the originating file.
+   * Once the editor has navigated to a different note, output is permanently
+   * redirected to the original file via the vault API (sticky redirect) so a
+   * mid-stream note switch can never split output across two notes.
+   */
+  private writeChunk(text: string): void {
+    if (text.length === 0) return;
+
+    if (this.shouldRedirectToFile()) {
+      this.appendToTargetFile(text);
+      return;
+    }
+
+    this.currentCursor = flushBufferedText(this.editor, text, this.currentCursor, this.setAtCursor);
+  }
+
+  /**
+   * Determine whether writes must be redirected to the original file because
+   * the editor is no longer displaying it. Sticky: stays true once tripped.
+   */
+  private shouldRedirectToFile(): boolean {
+    if (this.redirected) return true;
+    if (!this.app || !this.targetFile) return false;
+
+    const currentFile = getFileForEditor(this.app, this.editor);
+    if (currentFile?.path !== this.targetFile.path) {
+      this.redirected = true;
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Append text to the original file via the vault API, preserving order
+   * across concurrent flushes with a serialized promise queue.
+   */
+  private appendToTargetFile(text: string): void {
+    const app = this.app;
+    const file = this.targetFile;
+    if (!app || !file) return;
+
+    this.fileWriteQueue = this.fileWriteQueue
+      .then(() => app.vault.process(file, (data) => data + text))
+      .then(() => undefined)
+      .catch((err) => {
+        console.error("[ChatGPT MD] Failed to write streamed response to original file:", err);
+      });
+  }
+
+  /**
+   * Whether it is still safe to write directly to the editor (i.e. it has not
+   * navigated to a different note). Used by callers for cursor/header writes.
+   */
+  public canWriteToEditor(): boolean {
+    return !this.shouldRedirectToFile();
+  }
+
+  /**
+   * Whether output has been redirected to the original file at any point.
+   */
+  public isRedirected(): boolean {
+    return this.redirected;
+  }
+
+  /**
+   * Write text immediately (used for error messages), routing to the editor or
+   * the original file depending on where the editor currently points.
+   */
+  public writeImmediate(text: string): void {
+    this.writeChunk(text);
+  }
+
+  /**
+   * Await any pending redirected file writes so callers can safely run
+   * follow-up operations (e.g. appending a user delimiter) after streaming.
+   */
+  public async flushPendingFileWrites(): Promise<void> {
+    await this.fileWriteQueue;
   }
 
   /**

--- a/src/Types/AiTypes.ts
+++ b/src/Types/AiTypes.ts
@@ -1,5 +1,5 @@
 import { Message } from "src/Models/Message";
-import { Editor, MarkdownView } from "obsidian";
+import { App, Editor, MarkdownView, TFile } from "obsidian";
 import { ToolService } from "src/Services/ToolService";
 import { ChatGPT_MDSettings } from "src/Models/Config";
 import { EditorService } from "src/Services/EditorService";
@@ -51,7 +51,9 @@ export interface IAiApiService {
     setAtCursor?: boolean,
     apiKey?: string,
     settings?: ChatGPT_MDSettings,
-    toolService?: ToolService
+    toolService?: ToolService,
+    app?: App,
+    targetFile?: TFile | null
   ): Promise<{
     fullString: string;
     mode: string;
@@ -65,7 +67,8 @@ export interface IAiApiService {
     view: MarkdownView,
     settings: ChatGPT_MDSettings,
     messages: string[],
-    editorService: EditorService
+    editorService: EditorService,
+    targetFile?: TFile | null
   ): Promise<string>;
 
   /**

--- a/src/Utilities/EditorHelpers.ts
+++ b/src/Utilities/EditorHelpers.ts
@@ -1,4 +1,4 @@
-import { Editor } from "obsidian";
+import { App, Editor, MarkdownView, TFile } from "obsidian";
 import { HORIZONTAL_LINE_CLASS, NEWLINE, ROLE_ASSISTANT, ROLE_IDENTIFIER, ROLE_USER } from "src/Constants";
 import { getHeaderRole, getHeadingPrefix } from "src/Utilities/TextHelpers";
 
@@ -6,6 +6,29 @@ import { getHeaderRole, getHeadingPrefix } from "src/Utilities/TextHelpers";
  * Utility functions for editor operations
  * These are simple, stateless functions that can be used anywhere
  */
+
+/**
+ * Find the file currently bound to a given editor instance.
+ *
+ * Obsidian reuses a single Editor instance per workspace leaf and swaps the
+ * underlying document when the user navigates to a different note within the
+ * same tab. This means a captured `editor` reference can silently start
+ * pointing at a different file mid-operation. Use this to verify which file an
+ * editor is actually displaying before writing to it.
+ *
+ * @returns the file the editor currently displays, or null if it is not
+ * attached to any open markdown view (e.g. the note was closed).
+ */
+export function getFileForEditor(app: App, editor: Editor): TFile | null {
+  const leaves = app.workspace.getLeavesOfType("markdown");
+  for (const leaf of leaves) {
+    const view = leaf.view;
+    if (view instanceof MarkdownView && view.editor === editor) {
+      return view.file ?? null;
+    }
+  }
+  return null;
+}
 
 /**
  * Add a horizontal rule with a role header

--- a/src/__mocks__/obsidian.ts
+++ b/src/__mocks__/obsidian.ts
@@ -1,4 +1,5 @@
 // Mock Obsidian API for testing
+import { jest } from "@jest/globals";
 
 export class App {
   workspace = {


### PR DESCRIPTION
 ## Summary
  Fixes a bug where streaming a chat response in note A and then switching the
  tab to note B caused the response to be written into note B instead of note A.
  **Root cause:** Obsidian reuses a single editor instance per tab and swaps its
  document when you navigate to another note in the same tab. The chat command
  captured that live editor at invocation but wrote to it asynchronously during
  streaming, so once the tab switched notes, all subsequent output (and the
  trailing user delimiter / inferred title) landed in the wrong note.
  ## Changes
  - Add `getFileForEditor()` to detect which file an editor currently displays.
  - `StreamingHandler` verifies the editor still shows the original note before
    each write. Once the user navigates away, it **sticky-redirects** remaining
    output to the original file via `app.vault.process()` (ordered append queue).
    Live streaming is unchanged while the note stays active.
  - `AiProviderService` threads the originating app/file through the streaming
    path and only touches the editor (cursor, error text, tool notices) when it
    still shows the target note.
  - `MessageService` appends the trailing `role::user` delimiter to the original
    file when the editor has navigated away.
  - Title inference now renames the captured file instead of whatever note is
    currently active (same bug class).
  - Import `jest` in the obsidian test mock (the new runtime `obsidian` import
    surfaced an ESM module-scope reference).
## Note
  The one edge case: if you switch notes mid-stream while in at-cursor mode, the redirected text is appended to the end of the original file rather than at the old cursor position. That's intentional —
  once the note isn't in the visible editor, the cursor/selection no longer exists, so end-of-file append is the only safe option. The alternative (writing at a stale cursor in a hidden document) is
  exactly the corruption we're fixing.
  ## Test plan
  - [x] `yarn test` — 120 passing (added `StreamingHandler` tests covering
    on-target writes, redirect-on-switch, and sticky redirect)
  - [x] `yarn build` — type-check + production bundle succeed
  - [x] `yarn lint` — no new errors
  - [x] Manual: prompt in note A, switch tab to note B mid-stream → response
    stays in note A; note B untouched; reopening A shows the full response.
